### PR TITLE
Trimed trailing slashes causes files in other directories to be deleted as well

### DIFF
--- a/src/OVHAdapter.php
+++ b/src/OVHAdapter.php
@@ -144,7 +144,7 @@ class OVHAdapter extends AbstractAdapter
     {
         $paths = [];
         $prefix = '/'.$this->container->getName().'/';
-        $location = $this->applyPathPrefix($dirname);
+        $location = rtrim($this->applyPathPrefix($dirname), '/').'/';
         $objects = $this->container->objectList(['prefix' => $location]);
 
         foreach ($objects as $object) {


### PR DESCRIPTION
When deleting "foo", files in directory "foobar" are also deleted.
By adding a trailing slash before the request, we can prevent that.